### PR TITLE
fixed DDL.sql CASCADE for creating join tables

### DIFF
--- a/DDL.sql
+++ b/DDL.sql
@@ -1,7 +1,7 @@
 /* 
 * File: DDL.sql
 * Authors: Stef Timmermans, Derek Williams
-* Date: 05/12/2023
+* Date: 05/23/2023
 * Description:
 *   This file contains the Data Definition Queries
 *   and the sample inserts for the database. Database

--- a/DML.sql
+++ b/DML.sql
@@ -1,7 +1,7 @@
 /* 
 * File: DML.sql
 * Authors: Stef Timmermans, Derek Williams
-* Date: 05/12/2023
+* Date: 05/23/2023
 * Description:
 *   This file contains the data manipulation queries
 *   for the database. Database mocks the potential


### PR DESCRIPTION
DDL now compiles properly and enforces the correct CASCADE rules to update the join table pages whenever `Customers`, `Accounts`, and `Transactions` update or delete rows.